### PR TITLE
Update instructions and add a license

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2022 github
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 > This bootcamp is designed to help familiarize you with GitHub Advanced Security (GHAS) so that you can better understand how to use it in your own repositories.
 
 ## :mega: Prerequisites
-To participate in the workshop you need a GitHub account and need to be invited to the workshop organization [ghas-bootcamp](https://github.com/ghas-bootcamp). If your repository hasn't been automatically created in the workshop organization, either click `Use this template` and create a repository under this organization, or create a new repository and push a copy of the `ghas-bootcamp` repository.
+To participate in the workshop you need a GitHub account and need to be invited to the workshop organization [ghas-bootcamp](https://github.com/ghas-bootcamp). If your repository hasn't been automatically created in the workshop organization, either click `Use this template` and create a repository under this organization, or create a new repository and push a copy of the `ghas-bootcamp` repository to an organization with GHAS enabled.
 
 ```bash
 git clone https://github.com/ghas-bootcamp/ghas-bootcamp.git

--- a/exercises/codeql-cli.md
+++ b/exercises/codeql-cli.md
@@ -1,13 +1,20 @@
-### Getting started with the CodeQL CLI
+## Getting started with the CodeQL CLI
 
 When you want to generate a CodeQL database locally and run the pre-compiled queries against it, this is the way to go.
 
-First let's download the CodeQL bundle! Head over [here](https://github.com/github/codeql-action/releases ) and download the approprate bundle for your operating system.
-Once it's downloaded, untar the content to a CodeQL home folder and you can add CodeQL to your path if you'd like
+First let's download the CodeQL bundle!
 
-```
-export PATH="/Documents/codeql-home/codeql:$PATH"
-```
+### Pre-requisites
+
+You will need to make sure you have the GitHub CLI installed. For more information on how to install the CLI, check out this installation [doc](https://github.com/cli/cli#installation)
+
+### Install the extension
+
+Using the GitHub CLI, we will install the codeql cli,
+
+  1. `gh extensions install github/gh-codeql`
+  1. `sudo gh codeql install-stub` (this allows you to run `codeql` in your terminal without having to invoke `gh codeql`)
+  1. `codeql set-version latest` (this will auto download the latest version of the cli)
 
 Check to make sure you can use the CodeQL CLI
 
@@ -15,11 +22,16 @@ Check to make sure you can use the CodeQL CLI
 codeql --version
 ```
 
+## Using the CodeQL CLI
+
 Now we need to use the CodeQL CLI on an actual repository. Let's start here with our [GHAS training material](https://github.com/ghas-bootcamp/ghas-bootcamp)
 There's multiple languages being used here, so for the purposes of this tutorial let's try to scan the Javascript portions of the codebase. 
 
 Clone this repository and `cd` into it.
 
+### Install the Javascript Bundle
+
+We will need to download the latest javascript queries to scan the code with. In your terminal, run `codeql pack download codeql/javascript-queries`
 
 ### codeql database create
 
@@ -30,7 +42,7 @@ You can rely on the autobuild.sh script as well, or you can supply your own buil
 Please review this [list](https://codeql.github.com/docs/codeql-overview/supported-languages-and-frameworks/) of currently supported languages and frameworks.
 
 
-```
+```bash
 codeql database create db --language=javascript
 ```
 
@@ -52,18 +64,22 @@ Now that we have a database to work with, let's run some queries against it! We 
 - `$CODEQL_SUPPORT_LANGUAGE-security-extended.qls`
 - `$CODEQL_SUPPORT_LANGUAGE-security-and-quality.qls`
 
-If you have the CodeQL bundle on path, you can reference these query suites by their filenames. If you don't, you can use the full path to the query suite. 
-As mentioned in the beginning, the queries from the CodeQL bundle are pre-compiled. 
-If you have a custom query suite, you will see that CodeQL will create a compiled query plan.
+By default when we scan with `codeql/javascript-queries` it will default to `javascript-code-scanning.qls`.
 
-```
-codeql database analyze db javascript-code-scanning.qls --format=sarif-latest --output=codeql-javascript-results.sarif
+```bash
+codeql database analyze db --format=sarif-latest --output=codeql-javascript-results.sarif codeql/javascript-queries
 ```
 
 You will see the queries being evaluated. When this process is done, a SARIF should have been created. The SARIF contains results from the analysis. 
 If the results array is empty, it means no results were found. If you want to view the SARIF, you can use `jq` to parse through it, or you can use a SARIF Viewer, such as this [one](https://marketplace.visualstudio.com/items?itemName=WDGIS.MicrosoftSarifViewer). Also if you have the `vs-codeql-starter` [workspace](https://github.com/github/vscode-codeql-starter), you can run particular queries against an imported CodeQL database and see the analysis in the IDE.
 
-Here are some advanced things to note:
+To scan your code using the other query suites, you just need to append that to the original command
+
+```bash
+codeql database analyze db --format=sarif-latest --output=codeql-javascript-results.sarif codeql/javascript-queries:codeql-suites/javascript-security-extended.qls
+```
+
+#### Things to note
 - When dealing with multiple analyses for the same commit (whether you're analysing multiple languages or have parallelized builds for a monorepo), make sure to use the `--sarif-category` flag to categorize the analyses.
 Failure to do so, in particular on a pull request, can cause confusion in that Code Scanning may not be able to detect a baseline analysis to compare the PR results.
 - Use this [endpoint](https://docs.github.com/en/rest/reference/code-scanning#list-code-scanning-analyses-for-a-repository) to list the CodeQL analyses of a repository, so that you can inspect the category for each analysis.
@@ -84,7 +100,9 @@ The `--ref` and `--commit` flag combinations can be one of the following:
   - ` curl -H "Accept: application/vnd.github.v3+json" \\n  -H "Authorization: token $GH_TOKEN" \\n  https://api.github.com/repos/<org-name>/<repo-name>/pulls/<pull-request-number> | jq '.merge_commit_sha'`
   - The merge commit is a commit created to make sure PR checks are ran; this commit doesn't exist in the actual source tree/`git log`.
 
-```
+If you are supplying the `--commit` flag, make sure you use the full commit hash and not the shortened one
+
+```bash
 codeql github upload-results --repository=$GITHUB_REPOSITORY --ref=$GITHUB_REF --commit=$GITHUB_SHA --sarif=codeql-javascript-results.sarif --github-auth-stdin=<YOUR TOKEN>
 ```
 

--- a/exercises/lab 2 - secret-scanning.md
+++ b/exercises/lab 2 - secret-scanning.md
@@ -47,6 +47,8 @@ While we can close a detected secret as being used in a test, we can also config
 
     Use a pattern to exclude the file `storage-service/src/main/resources/application.dev.properties`
 
+    Merge your changes to `.github/secret_scanning.yml` to your default branch before going to the next step.
+
     <details>
     <summary>Solution</summary>
     A possible solution is:

--- a/exercises/lab 3 - code-scanning.md
+++ b/exercises/lab 3 - code-scanning.md
@@ -51,9 +51,10 @@ CodeQL requires a build of compiled languages, and an analysis job can fail if o
     <details>
     <summary>Solution</summary>
 
-        uses: actions/setup-java@v1
+        uses: actions/setup-java@v3.4.1
         with:
-            java-version: 15
+            java-version: 16
+            distribution: 'microsoft'
 
     </details>
 

--- a/exercises/lab 3 - code-scanning.md
+++ b/exercises/lab 3 - code-scanning.md
@@ -51,7 +51,7 @@ CodeQL requires a build of compiled languages, and an analysis job can fail if o
     <details>
     <summary>Solution</summary>
 
-        uses: actions/setup-java@v3.4.1
+        uses: actions/setup-java@v3
         with:
             java-version: 16
             distribution: 'microsoft'


### PR DESCRIPTION
## tl;dr
I went through this bootcamp recently and noticed some areas where the instructions may not be as clear or where we are using outdated actions modules so I am updating the bootcamp to reflect the latest changes.

This repo is also lacking a license so I am adding the MIT license.

I ran these changes by @s-samadi and she recommended I open a PR.

## Explanation of Changes

### README

In the README, the instructions were to use the template to create a repo in the `ghas-bootcamp` repo or to just create the repo and push the contents of this repo to it. Since I did not have access to this repo, I made a personal repo but in doing so you cannot fully complete the labs because things like the secret scanning dashboard is not available for public repos. I added a clarification in there that if we are creating the repo somewhere outside the org `ghas-bootcamp` they should do it in an org with GHAS enabled to be able to fully leverage this lab.

### Lab 2 - Secret Scanning Configuration

In this lab, we are asked to create a `secret_scanning.yml` to ignore some file paths so that we can experiment with pushing secrets in those files to see what the behaviour is like. While this is poorly documented, I had a discussion with the secret scanning team and confirmed with them that if a user creates a `secret_scanning.yml` and then pushes a file that is listed in `paths-ignore`, the secret scanning will still scan the file. 

This is actually expected behaviour because there exists a scenario that a developer can add new paths to be ignored and then leak tokens in those files to the repo without the repo admins agreeing and approving the changes to the ignore list first. The `secret_scanning.yml` must be merged to the default branch first before a developer can upload tokens into those files that are in the `secret_scanning.yml` to have them ignored. This applies to existing tokens already found and for push protection.

### Lab 3 - Code Scanning Configuration

We are asking users to add the `setup-java` actions step and in our example we tell them to use `actions/setup-java@v1` but if a user is adding this in the UI using the help prompts, the latest version for `actions/setup-java` is actually `3.4.1` or `v3`.  Support for Java 15 is dropped and so I am upping the version to 16. I did verify that the codebase will compile and that code scanning will complete with using Java 16.

The other addition is the `distribution` field which asks us to specify what kind of jdk we want to use. For simplicity, I chose `microsoft` and verified that the build will run to completion using these configurations. For more information, you can take a look at [actions/setup-java](https://github.com/actions/setup-java) repo.  

### Codeql CLI

I updated the documentation to get users to leverage the GitHub CLI to install and manage the CodeQL CLI. The previous documentation had users downloading releases and having to play with their PATH variable which for some people they may be uncomfortable with and it also introduces issues when you start downloading multiple versions of the cli and bundle and need to manage it. Having a non-standard installation method isn't a best practice. The GitHub CLI will install CodeQL into a more standard installation spot and managing the bundles will not require any PATH manipulations. It also helps to simplify the code scanning part as we no longer need to reference the full path for a query suite but we can now use relative paths.